### PR TITLE
Switched from numpy setup() to distutils setup()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from numpy.distutils.core import setup, Extension
+from setuptools import setup
+from numpy.distutils.core import Extension
 from numpy.distutils.misc_util import get_numpy_include_dirs 
 import os, sys
 


### PR DESCRIPTION
Now you can do "python setup.py develop" to compile the package in place.
