### PR TITLE
ENH(but cmdline API breakage): no implementation suffix in script name

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ In that case, make sure your `PATH` has `/home/foo/bin` and make sure the
 
 skeleton
 
-    gradient_unwarp.py infile outfile manufacturer -g <coefficient file> [optional arguments]
+    gradient_unwarp infile outfile manufacturer -g <coefficient file> [optional arguments]
 
 typical usage
 
-    gradient_unwarp.py sonata.mgh testoutson.mgh siemens -g coeff_Sonata.grad  --fovmin -.15 --fovmax .15 --numpoints 40
+    gradient_unwarp sonata.mgh testoutson.mgh siemens -g coeff_Sonata.grad  --fovmin -.15 --fovmax .15 --numpoints 40
 
-    gradient_unwarp.py avanto.mgh testoutava.mgh siemens -g coeff_AS05.grad -n
+    gradient_unwarp avanto.mgh testoutava.mgh siemens -g coeff_AS05.grad -n
 
 ### Positional Arguments
 

--- a/bin/gradient_unwarp
+++ b/bin/gradient_unwarp
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the gradunwarp package for the
+#   copyright and license terms.
+#
+### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+from gradunwarp.core.gradient_unwarp import argument_parse_gradunwarp, GradientUnwarpRunner
+
+if __name__ == '__main__':
+    args = argument_parse_gradunwarp()
+
+    grad_unwarp = GradientUnwarpRunner(args)
+
+    grad_unwarp.run()
+
+    grad_unwarp.write()

--- a/gradunwarp/core/gradient_unwarp.py
+++ b/gradunwarp/core/gradient_unwarp.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 #
 #   See COPYING file distributed along with the gradunwarp package for the
@@ -113,12 +112,3 @@ class GradientUnwarpRunner(object):
     def write(self):
         self.unwarper.write(self.args.outfile)
 
-
-if __name__ == '__main__':
-    args = argument_parse_gradunwarp()
-
-    grad_unwarp = GradientUnwarpRunner(args)
-
-    grad_unwarp.run()
-
-    grad_unwarp.write()

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ ext3 = Extension('gradunwarp.core.transform_coordinates_ext',
                  sources = ['gradunwarp/core/transform_coordinates_ext.c'],
                  extra_compile_args=['-O3'])
 
-scripts_cmd = ['gradunwarp/core/gradient_unwarp.py',]
+scripts_cmd = ['bin/gradient_unwarp',]
         
 
 def configuration(parent_package='', top_path=None):


### PR DESCRIPTION
It is generally advised practice, whenever implementation detail
is not relevant to the functionality.  This way new versions, even if
reimplemented in another language, could maintain the same interface.

Since there is no issues page activated -- I had to whine this way ;)  I totally understand if you don't merge it right away (or may be ever), but I still hope that you might consider adjusting this package and your pipelines accordingly at some point ;)
