### PR TITLE
Fix deprecations in nibabel and numpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ sudo apt install python3-venv
 ```
 before running the below.
 
-First, extract the gradunwarp tarball, and `cd` into the folder it creates. Then do:
+First, extract the gradunwarp tarball, and `cd` into the folder it creates. 
+Then do:
 ```bash
 python3 -m venv gradunwarp.build
 source gradunwarp.build/bin/activate
@@ -58,6 +59,22 @@ source "$PATH_TO_INSTALLATION"/gradunwarp.build/bin/activate
 ```
 to your scripts, where `"$PATH_TO_INSTALLATION"` should be replaced with the path where you installed gradunwarp.
 Note that you may need to `deactivate` the virtual environment after running gradunwarp in your scripts to use other environments.
+
+#### Install using a virtual environment for python2
+Installation using python2 is slightly different to that for python3 above.
+
+As above extract the gradunwarp tarball, and `cd` into the folder it creates. 
+Then do:
+```bash
+virtualenv -p python2 gradunwarp.build
+source gradunwarp.build/bin/activate
+pip install -r requirements_py2.txt
+pip install . 
+deactivate
+```
+Note that the requirements file is different and `virtualenv` is used instead of `venv`.
+
+This virtual environment can then be used in the same way as described for python3 above.
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,10 @@ First, extract the gradunwarp tarball, and `cd` into the folder it creates. Then
 ```bash
 python3 -m venv gradunwarp.build
 source gradunwarp.build/bin/activate
-pip3 install -r requirements.txt
-pip3 install . --no-cache-dir --no-binary=gradunwarp
+pip install -r requirements.txt
+pip install . 
 deactivate
 ```
-The arguments `--no-cache-dir --no-binary=gradunwarp` are required to suppress a warning arising from the version name of gradunwarp not complying with [python formatting rules](https://peps.python.org/pep-0440/).
 The command `deactivate` ensures that your python environment is set to the way it was before.
 
 After this installation, you can then use gradunwarp by adding

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ pip3 install . --user
 If you use the `--user` switch, you will need to add `/home/<username>/.local/bin` to your `PATH` environment variable, replacing `<username>` with your user name.
 
 ### Install using a virtual environment
+You may optionally choose to install gradunwarp into a python virtual environment in order to avoid possible interference with your existing python setup.
 If the [python virtual environment module](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments) is not already installed, then you may need to run
 ```bash
 sudo apt install python3-venv

--- a/README.md
+++ b/README.md
@@ -13,30 +13,54 @@ for use within the [HCP Minimal Preprocessing Pipelines][HCP Pipelines].
 
 ## Installation
 
-### Prerequisites
-
+### Install for all users
 You can install the necessary prerequisites in most Ubuntu or Debian-based distributions with this command:
+```bash
+sudo apt install python3-numpy python3-pip
 ```
-sudo apt-get install python3-numpy python3-pip
-```
-
-### Install
 
 For convenience the latest gradunwarp tarball can be downloaded from [here][gradunwarp-hcp-tarball].
 
 First, extract the gradunwarp tarball, and `cd` into the folder it creates. Then do:
-```
+```bash
+sudo pip3 install -r requirements.txt
 sudo pip3 install .
 ```
-If you don't have superuser permissions on the machine, you can use the `--user` switch of pip install:
-```
+
+#### Install with only user permissions
+If you don't have superuser permissions on the machine, you can use the `--user` switch of pip install instead of using `sudo`:
+```bash
+pip3 install -r requirements.txt --user
 pip3 install . --user
 ```
 If you use the `--user` switch, you will need to add `/home/<username>/.local/bin` to your `PATH` environment variable, replacing `<username>` with your user name.
 
-#### Details
+### Install using a virtual environment
+If the [python virtual environment module](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments) is not already installed, then you may need to run
+```bash
+sudo apt install python3-venv
+```
+before running the below.
 
-If you are on an old distribution that doesn't have the necessary versions of nibabel and its dependencies, here are the details of what you need:
+First, extract the gradunwarp tarball, and `cd` into the folder it creates. Then do:
+```bash
+python3 -m venv gradunwarp.build
+source gradunwarp.build/bin/activate
+pip3 install -r requirements.txt
+pip3 install . --no-cache-dir --no-binary=gradunwarp
+deactivate
+```
+The arguments `--no-cache-dir --no-binary=gradunwarp` are required to suppress a warning arising from the version name of gradunwarp not complying with [python formatting rules](https://peps.python.org/pep-0440/).
+The command `deactivate` ensures that your python environment is set to the way it was before.
+
+After this installation, you can then use gradunwarp by adding
+```
+source "$PATH_TO_INSTALLATION"/gradunwarp.build/bin/activate
+```
+to your scripts, where `"$PATH_TO_INSTALLATION"` should be replaced with the path where you installed gradunwarp.
+Note that you may need to `deactivate` the virtual environment after running gradunwarp in your scripts to use other environments.
+
+### Dependencies
 
 * Python (>=2.7 or 3.x)
 * [Numpy][Numpy]

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ Then do:
 ```bash
 virtualenv -p python2 gradunwarp.build
 source gradunwarp.build/bin/activate
-pip install -r requirements_py2.txt
+pip install -r requirements.txt
 pip install . 
 deactivate
 ```
-Note that the requirements file is different and `virtualenv` is used instead of `venv`.
+Note that `virtualenv` is used instead of `venv`.
 
 This virtual environment can then be used in the same way as described for python3 above.
 
@@ -82,7 +82,7 @@ This virtual environment can then be used in the same way as described for pytho
 * [Numpy][Numpy]
 * [Scipy][Scipy]
 * Numpy devel package, if separate (to compile external modules written in C)
-* [nibabel][nibabel] (1.2.0 or later, for MGH support)
+* [nibabel][nibabel] (2.0 or later for python2.7, 3.2.1 or later for python3.x)
 
 Dependencies of nibabel:
 
@@ -92,7 +92,7 @@ Dependencies of nibabel:
 
 ## Usage
 
-Note that a core component of `gradient_unwarp.py` (`unwarp_resample.py`) uses a `subprocess` call to the FSL tools `fslval` and `fslorient`. So FSL must be [installed][installed] and its configuration file correctly [sourced][sourced] (i.e., `FSLDIR` and `FSLOUTPUTTYPE` must be defined appropriately in your environment, and `${FSLDIR}/bin` must be in your `PATH` and contain `fslval`, `fslorient`, and `fslhd` -- this should be done for you by the SetUpHCPPipeline.sh script). FSLOUTPUTTYPE must be set to NIFTI_GZ, which is the default.
+Note that a core component of `gradient_unwarp.py` (`unwarp_resample.py`) uses a `subprocess` call to the FSL tools `fslval` and `fslorient`. So FSL must be [installed][installed] and its configuration file correctly [sourced][sourced] (i.e., `FSLDIR` and `FSLOUTPUTTYPE` must be defined appropriately in your environment, and `${FSLDIR}/bin` must be in your `PATH` and contain `fslval`, `fslorient`, and `fslhd` -- this should be done for you by the SetUpHCPPipeline.sh script). FSLOUTPUTTYPE must be set to NIFTI\_GZ, which is the default.
 
 skeleton
 

--- a/gradunwarp/core/unwarp_resample.py
+++ b/gradunwarp/core/unwarp_resample.py
@@ -114,7 +114,7 @@ class Unwarper(object):
         m_ras2lai = np.array([[-1.0, 0.0, 0.0, 0.0],
                              [0.0, 1.0, 0.0, 0.0],
                              [0.0, 0.0, -1.0, 0.0],
-                             [0.0, 0.0, 0.0, 1.0]], dtype=np.float)
+                             [0.0, 0.0, 0.0, 1.0]], dtype=np.float64)
         m_rcs2lai = np.dot(m_ras2lai, self.m_rcs2ras)
         m_rcs2lai_nohalf = m_rcs2lai[:, :]
 
@@ -215,12 +215,12 @@ class Unwarper(object):
             m_vox2fsl = np.array([[-1.0*pixdim1, 0.0, 0.0, pixdim1*(dim1-1)],
                               [0.0, pixdim2, 0.0, 0.0],
                               [0.0, 0.0, pixdim3, 0.0],
-                              [0.0, 0.0, 0.0, 1.0]], dtype=np.float)
+                              [0.0, 0.0, 0.0, 1.0]], dtype=np.float64)
         else:
             m_vox2fsl = np.array([[pixdim1, 0.0, 0.0, 0.0],
                               [0.0, pixdim2, 0.0, 0.0],
                               [0.0, 0.0, pixdim3, 0.0],
-                              [0.0, 0.0, 0.0, 1.0]], dtype=np.float)
+                              [0.0, 0.0, 0.0, 1.0]], dtype=np.float64)
 															
         log.info('Unwarping slice by slice')
         # for every slice

--- a/gradunwarp/core/utils.py
+++ b/gradunwarp/core/utils.py
@@ -62,7 +62,7 @@ def get_vol_affine(infile):
         raise ImportError('gradunwarp needs nibabel for I/O of mgz/nifti files.'
                           ' Please install')
     nibimage = nib.load(infile)
-    return nibimage.get_data(), nibimage.get_affine()
+    return nibimage.get_data(), nibimage.affine
 
 
 # memoized factorial

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-nibabel>=3.2.1
+nibabel >= 3.2.1 ; python_version > "3.0"
+nibabel >= 2.0 ; python_version < "3.0"
 numpy
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+nibabel>=4.0
+numpy
+scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nibabel >= 3.2.1 ; python_version > "3.0"
+nibabel >= 3.2.1 ; python_version >= "3.0"
 nibabel >= 2.0 ; python_version < "3.0"
 numpy
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-nibabel>=4.0
+nibabel>=3.2.1
 numpy
 scipy

--- a/requirements_py2.txt
+++ b/requirements_py2.txt
@@ -1,3 +1,0 @@
-nibabel>=2.0
-numpy
-scipy

--- a/requirements_py2.txt
+++ b/requirements_py2.txt
@@ -1,0 +1,3 @@
+nibabel>=2.0
+numpy
+scipy

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def configuration(parent_package='', top_path=None):
     return config
 
 setup(name='gradunwarp',
-      version = 'HCP-1.2.0',
+      version = '1.2.0+HCP',
       description = 'HCP version of Gradient Unwarping Package for Python/Numpy',
       author = 'Human Connectome Project',
       py_modules  = mods,


### PR DESCRIPTION
Both [nibabel](https://nipy.org/nibabel/reference/nibabel.spatialimages.html#nibabel.spatialimages.SpatialImage.get_affine) and [numpy](https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated) have recently changed deprecation warnings to deprecation errors that break the installation process of gradunwarp. The first of these was already noted in issue #7. The changes here fix these deprecation errors.

I also made some changes to the description of the installation process and included a [requirements.txt](https://pip.pypa.io/en/stable/reference/requirements-file-format/) file to try and make the installation a little easier. In principle specific versions of packages should be specified in the requirements file, but I have not done this as I'm not sure what versions you test with.

These changes will potentially cause issues for backwards compatibility with python2.