### PR TITLE
CI: Enable GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: Test suite
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Commented sections to be uncommented once CI is active
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    # strategy:
+    #   matrix:
+    #     python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    #     requires: ["", "requirements.txt"]
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      # - name: Set up Python ${{ matrix.python-version }}
+      #   uses: conda-incubator/setup-miniconda@v2
+      #   with:
+      #     python-version: ${{ matrix.python-version }}
+      # - name: Update pip and pytest
+      #   run: python -m pip install --upgrade pip pytest
+      # - name: Install requires
+      #   run: |
+      #     python -m pip install -r ${{ matrix.requires }}
+      #   if: ${{ matrix.requires }}
+      # - name: Install gradunwarp
+      #   run: |
+      #     python -m pip install .
+      # - name: Test
+      #   run: pytest --pyargs gradunwarp
+      #   working-directory: /tmp


### PR DESCRIPTION
In preparation for #10.

GitHub actions won't start running on a pull request. It needs to be present in master. This will get it going with an absolutely minimal action, and then we can open a new PR, uncomment the tests, make sure they work, and update packaging.