### PR TITLE
CI: Install and test with Python and fslavwutils

### DIFF
--- a/.github/test-env.yml
+++ b/.github/test-env.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - fsl-avwutils=2209.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,27 +18,34 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # strategy:
-    #   matrix:
-    #     python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-    #     requires: ["", "requirements.txt"]
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        requires: ["requirements.txt"]
+        # Can't use 2.7 with fsl from conda
+        # python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        # Can't drop requirements.txt without build isolation
+        # requires: ["", "requirements.txt"]
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-      # - name: Set up Python ${{ matrix.python-version }}
-      #   uses: conda-incubator/setup-miniconda@v2
-      #   with:
-      #     python-version: ${{ matrix.python-version }}
-      # - name: Update pip and pytest
-      #   run: python -m pip install --upgrade pip pytest
-      # - name: Install requires
-      #   run: |
-      #     python -m pip install -r ${{ matrix.requires }}
-      #   if: ${{ matrix.requires }}
-      # - name: Install gradunwarp
-      #   run: |
-      #     python -m pip install .
-      # - name: Test
-      #   run: pytest --pyargs gradunwarp
-      #   working-directory: /tmp
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          mamba-version: "*"
+          channels: https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/public/,conda-forge
+          environment-file: .github/test-env.yml
+      - name: Update pip and pytest
+        run: python -m pip install --upgrade pip pytest
+      - name: Install requires
+        run: |
+          python -m pip install -r ${{ matrix.requires }}
+        if: ${{ matrix.requires }}
+      - name: Install gradunwarp
+        run: |
+          python -m pip install .
+      - name: Test
+        run: pytest --pyargs gradunwarp
+        working-directory: /tmp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,4 +57,5 @@ jobs:
         run: |
           python -m pip install .
       - name: Test
-        run: pytest --cov gradunwarp
+        run: pytest --pyargs gradunwarp --cov gradunwarp
+        working-directory: /tmp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           channels: https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/public/,conda-forge
           environment-file: .github/test-env.yml
       - name: Update pip and pytest
-        run: python -m pip install --upgrade pip pytest
+        run: python -m pip install --upgrade pip pytest pytest-cov
       - name: Install requires
         run: |
           python -m pip install -r ${{ matrix.requires }}
@@ -47,5 +47,4 @@ jobs:
         run: |
           python -m pip install .
       - name: Test
-        run: pytest --pyargs gradunwarp
-        working-directory: /tmp
+        run: pytest --cov gradunwarp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,12 @@ jobs:
           mamba-version: "*"
           channels: https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/public/,conda-forge
           environment-file: .github/test-env.yml
+      - name: Check environment
+        run: |
+          which python
+          which python3
+          echo $CONDA_PREFIX
+          echo $PATH
       - name: Update pip and pytest
         run: python -m pip install --upgrade pip pytest pytest-cov
       - name: Install requires

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash -el {0}
+
 # Commented sections to be uncommented once CI is active
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,3 +59,6 @@ jobs:
       - name: Test
         run: pytest --pyargs gradunwarp --cov gradunwarp
         working-directory: /tmp
+        env:
+          FSLOUTPUTTYPE: NIFTI_GZ
+          FSLDIR: /usr/share/miniconda/envs/test

--- a/gradunwarp/core/tests/test_gradient_unwarp.py
+++ b/gradunwarp/core/tests/test_gradient_unwarp.py
@@ -1,0 +1,42 @@
+import os
+import tempfile
+
+import numpy as np
+import nibabel as nb
+from nibabel.tmpdirs import InTemporaryDirectory
+
+from ..gradient_unwarp import GradientUnwarpRunner
+
+
+class Arguments:
+    """Just something to dump args into"""
+
+
+def test_trivial_unwarp():
+    with InTemporaryDirectory() as tmpdir:
+        # Siemens Allegra coefficient arrays are 15x15, keeping things small and fast
+        coef_file = "allegra.coef"
+        open(coef_file, 'wb').close()  # touch
+        assert os.path.exists(coef_file)
+
+        orig_arr = np.arange(24).reshape(2, 3, 4)
+
+        # Use centered LAS affine for simplicity. Easiest way to get it is
+        # creating the image and asking nibabel to make it for us.
+        img = nb.Nifti1Image(orig_arr.astype("float32"), None)
+        img.set_sform(img.header.get_base_affine(), 1)
+        img.set_qform(img.header.get_base_affine(), 1)
+        img.to_filename("test.nii")
+
+        args = Arguments()
+        args.infile = "test.nii"
+        args.outfile = "out.nii"
+        args.vendor = "siemens"
+        args.coeffile = coef_file
+
+        unwarper = GradientUnwarpRunner(args)
+        unwarper.run()
+        unwarper.write()
+
+        unwarped_img = nb.load("out.nii")
+        assert np.allclose(unwarped_img.get_fdata(), orig_arr)

--- a/gradunwarp/core/utils.py
+++ b/gradunwarp/core/utils.py
@@ -62,7 +62,7 @@ def get_vol_affine(infile):
         raise ImportError('gradunwarp needs nibabel for I/O of mgz/nifti files.'
                           ' Please install')
     nibimage = nib.load(infile)
-    return nibimage.get_data(), nibimage.affine
+    return np.asanyarray(nibimage.dataobj), nibimage.affine
 
 
 # memoized factorial

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ mods = ['gradunwarp.core.coeffs', 'gradunwarp.core.globals',
         'gradunwarp.core.unwarp_resample',
         'gradunwarp.core.gradient_unwarp',
         'gradunwarp.core.tests.test_utils',
+        'gradunwarp.core.tests.test_gradient_unwarp',
        ]
 
 dats = [('gradunwarp/core/', ['gradunwarp/core/interp3_ext.c']),


### PR DESCRIPTION
Gets tests working from Python 3.6-3.11. 2.7 clashes with fslavwutils, which prevents testing while there's an fsl dependency.

It looks like there's not a lot of testing going on (coverage is 5%)... Do you have test data you use to actually run the program? I know there are some proprietary files we probably can't publish, but presumably we could make some identity file just to make sure the code is exercised and changes don't damage that.