### PR TITLE
MNT: Drop FSL dependency, test on Python 2.7

### DIFF
--- a/.github/test-env.yml
+++ b/.github/test-env.yml
@@ -1,2 +1,0 @@
-dependencies:
-  - fsl-avwutils=2209.0

--- a/.github/test-env.yml
+++ b/.github/test-env.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - fsl-avwutils=2209.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,27 +18,34 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # strategy:
-    #   matrix:
-    #     python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-    #     requires: ["", "requirements.txt"]
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        requires: ["requirements.txt"]
+        # Can't use 2.7 with fsl from conda
+        # python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        # Can't drop requirements.txt without build isolation
+        # requires: ["", "requirements.txt"]
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-      # - name: Set up Python ${{ matrix.python-version }}
-      #   uses: conda-incubator/setup-miniconda@v2
-      #   with:
-      #     python-version: ${{ matrix.python-version }}
-      # - name: Update pip and pytest
-      #   run: python -m pip install --upgrade pip pytest
-      # - name: Install requires
-      #   run: |
-      #     python -m pip install -r ${{ matrix.requires }}
-      #   if: ${{ matrix.requires }}
-      # - name: Install gradunwarp
-      #   run: |
-      #     python -m pip install .
-      # - name: Test
-      #   run: pytest --pyargs gradunwarp
-      #   working-directory: /tmp
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          mamba-version: "*"
+          channels: https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/public/,conda-forge
+          environment-file: .github/test-env.yml
+      - name: Update pip and pytest
+        run: python -m pip install --upgrade pip pytest
+      - name: Install requires
+        run: |
+          python -m pip install -r ${{ matrix.requires }}
+        if: ${{ matrix.requires }}
+      - name: Install gradunwarp
+        run: |
+          python -m pip install .
+      - name: Test
+        run: pytest --pyargs gradunwarp
+        working-directory: /tmp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         requires: ["requirements.txt"]
-        # Can't use 2.7 with fsl from conda
-        # python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         # Can't drop requirements.txt without build isolation
         # requires: ["", "requirements.txt"]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,4 +57,5 @@ jobs:
         run: |
           python -m pip install .
       - name: Test
-        run: pytest --cov gradunwarp
+        run: pytest --pyargs gradunwarp --cov gradunwarp
+        working-directory: /tmp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           channels: https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/public/,conda-forge
           environment-file: .github/test-env.yml
       - name: Update pip and pytest
-        run: python -m pip install --upgrade pip pytest
+        run: python -m pip install --upgrade pip pytest pytest-cov
       - name: Install requires
         run: |
           python -m pip install -r ${{ matrix.requires }}
@@ -47,5 +47,4 @@ jobs:
         run: |
           python -m pip install .
       - name: Test
-        run: pytest --pyargs gradunwarp
-        working-directory: /tmp
+        run: pytest --cov gradunwarp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,12 @@ jobs:
           mamba-version: "*"
           channels: https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/public/,conda-forge
           environment-file: .github/test-env.yml
+      - name: Check environment
+        run: |
+          which python
+          which python3
+          echo $CONDA_PREFIX
+          echo $PATH
       - name: Update pip and pytest
         run: python -m pip install --upgrade pip pytest pytest-cov
       - name: Install requires

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash -el {0}
+
 # Commented sections to be uncommented once CI is active
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
-          mamba-version: "*"
-          channels: https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/public/,conda-forge
-          environment-file: .github/test-env.yml
       - name: Check environment
         run: |
           which python
@@ -59,6 +56,3 @@ jobs:
       - name: Test
         run: pytest --pyargs gradunwarp --cov gradunwarp
         working-directory: /tmp
-        env:
-          FSLOUTPUTTYPE: NIFTI_GZ
-          FSLDIR: /usr/share/miniconda/envs/test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,3 +59,6 @@ jobs:
       - name: Test
         run: pytest --pyargs gradunwarp --cov gradunwarp
         working-directory: /tmp
+        env:
+          FSLOUTPUTTYPE: NIFTI_GZ
+          FSLDIR: /usr/share/miniconda/envs/test

--- a/README.md
+++ b/README.md
@@ -93,8 +93,6 @@ Dependencies of nibabel:
 
 ## Usage
 
-Note that a core component of `gradient_unwarp.py` (`unwarp_resample.py`) uses a `subprocess` call to the FSL tools `fslval` and `fslorient`. So FSL must be [installed][installed] and its configuration file correctly [sourced][sourced] (i.e., `FSLDIR` and `FSLOUTPUTTYPE` must be defined appropriately in your environment, and `${FSLDIR}/bin` must be in your `PATH` and contain `fslval`, `fslorient`, and `fslhd` -- this should be done for you by the SetUpHCPPipeline.sh script). FSLOUTPUTTYPE must be set to NIFTI\_GZ, which is the default.
-
 skeleton
 
     gradient_unwarp.py infile outfile manufacturer -g <coefficient file> [optional arguments]
@@ -202,5 +200,3 @@ To do this, after cloning the [HCP Pipelines Repository][HCP Pipelines] use:
 [sphinx]: http://sphinx-doc.org
 [Copying.md]: Copying.md
 [HCP Pipelines]: https://github.com/Washington-University/Pipelines
-[installed]: https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FslInstallation/Linux
-[sourced]: https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FslInstallation/ShellSetup

--- a/gradunwarp/core/tests/test_gradient_unwarp.py
+++ b/gradunwarp/core/tests/test_gradient_unwarp.py
@@ -1,0 +1,42 @@
+import os
+import tempfile
+
+import numpy as np
+import nibabel as nb
+from nibabel.tmpdirs import InTemporaryDirectory
+
+from ..gradient_unwarp import GradientUnwarpRunner
+
+
+class Arguments:
+    """Just something to dump args into"""
+
+
+def test_trivial_unwarp():
+    with InTemporaryDirectory() as tmpdir:
+        # Siemens Allegra coefficient arrays are 15x15, keeping things small and fast
+        coef_file = "allegra.coef"
+        open(coef_file, 'wb').close()  # touch
+        assert os.path.exists(coef_file)
+
+        orig_arr = np.arange(24).reshape(2, 3, 4)
+
+        # Use centered LAS affine for simplicity. Easiest way to get it is
+        # creating the image and asking nibabel to make it for us.
+        img = nb.Nifti1Image(orig_arr.astype("float32"), None)
+        img.set_sform(img.header.get_base_affine(), 1)
+        img.set_qform(img.header.get_base_affine(), 1)
+        img.to_filename("test.nii")
+
+        args = Arguments()
+        args.infile = "test.nii"
+        args.outfile = "out.nii"
+        args.vendor = "siemens"
+        args.coeffile = coef_file
+
+        unwarper = GradientUnwarpRunner(args)
+        unwarper.run()
+        unwarper.write()
+
+        unwarped_img = nb.load("out.nii")
+        assert np.allclose(unwarped_img.get_fdata(), orig_arr)

--- a/gradunwarp/core/utils.py
+++ b/gradunwarp/core/utils.py
@@ -62,7 +62,7 @@ def get_vol_affine(infile):
         raise ImportError('gradunwarp needs nibabel for I/O of mgz/nifti files.'
                           ' Please install')
     nibimage = nib.load(infile)
-    return nibimage.get_data(), nibimage.affine
+    return np.asanyarray(nibimage.dataobj), nibimage.affine
 
 
 # memoized factorial

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ mods = ['gradunwarp.core.coeffs', 'gradunwarp.core.globals',
         'gradunwarp.core.unwarp_resample',
         'gradunwarp.core.gradient_unwarp',
         'gradunwarp.core.tests.test_utils',
+        'gradunwarp.core.tests.test_gradient_unwarp',
        ]
 
 dats = [('gradunwarp/core/', ['gradunwarp/core/interp3_ext.c']),


### PR DESCRIPTION
This builds on #13. Starting with a test run and then will try to add Python 2 to the test matrix.

Diff from #13: https://github.com/effigies/gradunwarp/compare/ci/testing...mnt/drop-fsl

Closes #13.