### PR TITLE
CI: Add token to allow packages to upload

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -137,6 +137,8 @@ jobs:
     environment: "Package deployment"
     needs: [pre-publish]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
These missing lines prevented the package from uploading to PyPI: https://github.com/Washington-University/gradunwarp/actions/runs/7227335329

Note that this won't work unless https://github.com/pypi/support/issues/3455 is resolved. If that is resolved, this would be for future uploads. I have downloaded all the packages and can upload them as soon as there is notice.