### PR TITLE
Fix off-by-one error in computing XYZ2RCS transform

### DIFF
--- a/gradunwarp/core/unwarp_resample.py
+++ b/gradunwarp/core/unwarp_resample.py
@@ -71,7 +71,7 @@ class Unwarper(object):
         vec = np.linspace(fovmin, fovmax, numpoints)
         gvx, gvy, gvz = np.meshgrid(vec, vec, vec)
         # mm
-        cf = (fovmax - fovmin) / numpoints
+        cf = (fovmax - fovmin) / (numpoints - 1)
 
         # deduce the transformation from rcs to grid
         g_rcs2xyz = np.array( [[0, cf, 0, fovmin],


### PR DESCRIPTION
Bug in field estimation that dates back to at least 275b8881a8041ff40b55ade3114a76e2eeb37828 (I've not bothered to test before that).

Construction of the transformation between voxelspace and realspace has an off-by-one error in its interaction with `numpy.linspace()`, compressing the whole field estimate toward the point [-fovmin, -fovmin, -fovmin].

I have not tested the correspondence between correction with this software and the vendor-applied correction.

Experiment: 1mm isotropic image containing unit deformation field (each voxel contains its own realspace position); apply correction; convert deformation field to displacement field. Repeat for different lattice densities. Ideally an increased lattice resolution should yield a higher resolution estimation of the field, not result in the field moving in space.

Before fix:

<img width="275" height="274" alt="before_small" src="https://github.com/user-attachments/assets/ef03acd7-aad3-4216-9e02-3f37624e4be3" />

After fix:

<img width="275" height="274" alt="after_small" src="https://github.com/user-attachments/assets/b4a37bbb-522c-4f4c-a945-2a9895986144" />
